### PR TITLE
Reducing spaces between sections

### DIFF
--- a/src/components/Activities.tsx
+++ b/src/components/Activities.tsx
@@ -16,7 +16,7 @@ const Link = styled.a`
 
 const Activities = ({ activities }: ActivitiesProps) => {
   return (
-    <Section bg='gray.100' pb={['5', '6', '7']}>
+    <Section bg='gray.100' pb={['5', '6']}>
       <Container>
         <Heading color='blue' fontSize={['5', '6', '7']} mb={['4', '4', '5']}>
           Recent Activities

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -6,7 +6,7 @@ type ProjectsProps = {
 }
 
 const Projects = ({ projects }: ProjectsProps) => (
-  <Section bg='gray.100'>
+  <Section bg='gray.100' pt={['5', '6']}>
     <Container>
       <Heading color='blue' fontSize={['7', '8', '9']}>
         Projects

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -5,7 +5,7 @@ const Section = styled(Box)``
 
 Section.defaultProps = {
   as: 'section',
-  py: ['5', '6'],
+  py: '5',
 }
 
 export default Section


### PR DESCRIPTION
This closes #45. I've also reduced the space after `Recent Activities` as well.

![image](https://user-images.githubusercontent.com/50931490/208499525-4dd0b2f0-20bf-4908-bbbf-ca7c0aec5c32.png)
![image](https://user-images.githubusercontent.com/50931490/208499624-e7563472-99a5-4a4b-97dd-fca65aa5f987.png)
![image](https://user-images.githubusercontent.com/50931490/208499965-a81cac4c-eaf4-4cee-847c-cac8d42d0bc3.png)
